### PR TITLE
Expand docs and comments for learners

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,252 +1,185 @@
-# Object-Based Soundscape (Jetson → Score → Render)
+# VidObjectifier — camera to noise box
 
-*A small machine watches images and writes music about them.*  
-Jetson Nano (or any CUDA Jetson) analyzes video streams, emits a time-stamped **score** (`CSV`/`JSONL`), and a **SuperCollider** renderer plays a dense, multi-timbral sound field (default **20 voices**). Use prerecorded videos or live feeds from TouchDesigner via RTSP/NDI bridge.
+*A tiny GPU watches video and scribbles a score; SuperCollider turns the scribble into a noisy choir.*
 
-```
-[TD sources / files] → [Jetson: detector+characterizer] → score.csv/jsonl
-                                                      ↓
-                                            [Renderer: SuperCollider]
-                                                      ↓
-                                  (stereo / 8-out ring / binaural print)
-```
-
-## Why this exists
-- **Low cost, high grit.** Free tools (SuperCollider, JACK, Ardour/REAPER eval).
-- **Multi-timbral by design.** Each tracked object gets a “character vector” that maps to synthesis.
-- **Live or offline.** Works from files, or live streams pre-mix and/or post-mix.
+This repo is half diary, half toolkit.  It's for anyone who wants to poke at the
+idea of **objects in a camera frame becoming musical voices**.  The code is kept
+small and loud on purpose so you can read it like liner notes.
 
 ---
 
-## Repo layout
+## In plain English
+
+There are only two moving parts:
+
+1. **Analyzer** (`analyzer/vid2score.py`)
+   - Python script that runs on a Jetson Nano (or any CUDA Jetson).
+   - Looks at a video file or live stream, spots objects with YOLO, and writes a
+     timestamped **score** as `CSV` or `JSONL`.
+2. **Renderer** (`renderer/render.scd` or `renderer/render_ring8.scd`)
+   - SuperCollider patch that reads the score and gives every object a voice.
+   - Default budget is **20 voices**, so things stay musical instead of mush.
+
+Picture a security camera feeding a garage band.
+
+```
+[video file / TouchDesigner] → [Jetson: detector + characterizer] → score.csv
+                                                     ↓
+                                            [SuperCollider renderer]
+                                                     ↓
+                                     (stereo / 8‑channel ring / binaural)
+```
+
+---
+
+## Why bother?
+
+- **Low cost, high grit.** Everything here runs on free tools: SuperCollider,
+  JACK, and a Jetson that you probably already cooked noodles on.
+- **Every object gets a personality.** The analyzer measures position, speed,
+  color, even a janky "glitch" metric.  The renderer maps those numbers to
+  timbre.
+- **Live or offline.** Feed it prerecorded footage, or sling live frames from
+  TouchDesigner over RTSP/NDI.
+
+---
+
+## What's in the box?
 
 ```
 .
 ├── analyzer/
-│   └── vid2score.py           # file/stream → score.csv/jsonl
+│   └── vid2score.py           # video/stream → score.csv
 ├── renderer/
-│   ├── render.scd             # SuperCollider renderer (stereo; 20-voice budget)
-│   ├── render_ring8.scd       # 8‑channel ring renderer (no external VBAP plugin)
-│   ├── mapping.scd            # base class→timbre map + routing
+│   ├── render.scd             # SuperCollider renderer (stereo)
+│   ├── render_ring8.scd       # 8‑channel ring renderer
+│   ├── mapping.scd            # default class→timbre map
 │   ├── mapping_steel_mill.scd # preset 1: steel, presses, belts
 │   ├── mapping_neon_glass.scd # preset 2: glass, hiss, sheen
 │   └── mapping_rust_choir.scd # preset 3: drones, rust, vocals-of-metal
 ├── config/
-│   └── timbre_map.yaml        # optional declarative map (reference)
+│   └── timbre_map.yaml        # optional YAML reference
 ├── examples/
-│   ├── input.mp4              # (put your file here)
+│   ├── input.mp4              # drop your video here
 │   └── score_example.csv      # tiny header-only example
-└── README.md                  # this file
+└── README.md                  # you are here
 ```
 
-Clone and drop your own media into `examples/` as you like.
+Clone the repo, throw your own media into `examples/`, and hack away.
 
 ---
 
-## Prerequisites
+## Getting set up
 
-### Jetson side (Nano is fine)
-- JetPack flashed and updated, active cooling recommended.
-- Python 3.8+, `pip`, `ffmpeg`.
-- Python packages: `ultralytics`, `opencv-python`, `numpy`.
-
-### Renderer side (any Linux/macOS machine)
-- **SuperCollider** (free)
-- **JACK2** + **QjackCtl** (for easy device routing)
-- Optional: **Ardour** (free/open) or **REAPER** (uncrippled evaluation) to record multichannel stems.
-
----
-
-## Install (Jetson)
+### On the Jetson (Nano is fine)
 
 ```bash
 sudo apt update && sudo apt install -y ffmpeg python3-pip
 pip3 install --upgrade pip
 pip3 install ultralytics opencv-python numpy
 
-# (optional but helpful)
+# optional but makes the Nano run spicy hot
 sudo nvpmodel -m 0 && sudo jetson_clocks
 ```
 
+### On the render machine (Linux or macOS)
+
+- [SuperCollider](https://supercollider.github.io/) — free, friendly synth
+  language.
+- [JACK2](https://jackaudio.org/) + QjackCtl — for routing audio devices.
+- Optional: **Ardour** (open-source) or **REAPER** (generous demo) to record
+  multichannel stems.
+
 ---
 
-## Analyzer: video/stream → score
+## Running the analyzer
 
-The analyzer writes a newline-timed **score** with spatial + “character” features.
+The script writes a newline‑timed score with spatial and color features.  The
+score is just text; open it in a spreadsheet if that makes you smile.
 
-**`analyzer/vid2score.py`**
-
-```python
-#!/usr/bin/env python3
-# File: analyzer/vid2score.py
-import argparse, csv, math, cv2, numpy as np
-from ultralytics import YOLO
-
-def glitch_meter(gray):
-    sobelx = cv2.Sobel(gray, cv2.CV_32F, 1, 0, ksize=3)
-    return float(np.clip(np.mean(np.abs(sobelx))/64.0, 0.0, 1.0))
-
-def to_polar(cx, cy, area, W, H):
-    az  = (cx/W)*360.0 - 180.0
-    el  = (1 - cy/H)*60.0 - 30.0
-    dist = max(0.05, 1.0 - area/(W*H))
-    return az, el, dist
-
-def hsv_stats(bgr_roi):
-    if bgr_roi.size == 0: return 0.0,0.0,0.0
-    hsv = cv2.cvtColor(bgr_roi, cv2.COLOR_BGR2HSV)
-    h = float(np.mean(hsv[:,:,0]) * 2.0)       # 0..360°
-    s = float(np.mean(hsv[:,:,1]) / 255.0)     # 0..1
-    v = float(np.mean(hsv[:,:,2]) / 255.0)     # 0..1
-    return h,s,v
-
-def edge_density(gray_roi):
-    if gray_roi.size == 0: return 0.0
-    return float(np.clip(cv2.Laplacian(gray_roi, cv2.CV_32F).var()/1000.0, 0.0, 1.0))
-
-def main(args):
-    cap  = cv2.VideoCapture(args.video)
-    assert cap.isOpened(), f"Cannot open {args.video}"
-    fps  = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    W    = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    H    = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
-    model = YOLO(args.model)
-
-    prev_center = {}
-    t = 0.0
-    out = open(args.out, "w", newline="")
-    wr = csv.writer(out)
-    wr.writerow(["t","stream","oid","cls","az","el","dist","spd","conf","glitch","hue","sat","val","edge"])
-    stream_id = args.stream_id
-
-    for r in model.track(source=args.video, stream=True, imgsz=args.imgsz, conf=args.conf, verbose=False):
-        t += 1.0/fps
-        frame = getattr(r, "orig_img", None)
-        gval = 0.0
-        if frame is not None:
-            gval = glitch_meter(cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY))
-        boxes = r.boxes
-        if boxes is None: continue
-
-        for b in boxes:
-            if b.id is None: continue
-            oid  = int(b.id.item())
-            cls  = int(b.cls.item())
-            conf = float(b.conf.item())
-
-            x1,y1,x2,y2 = [float(v) for v in b.xyxy[0].tolist()]
-            cx, cy = (x1+x2)/2, (y1+y2)/2
-            area   = max(1.0, (x2-x1)*(y2-y1))
-            az, el, dist = to_polar(cx, cy, area, W, H)
-
-            spd = 0.0
-            if oid in prev_center:
-                px, py = prev_center[oid]
-                dx, dy = (cx-px)/W, (cy-py)/H
-                spd = math.sqrt(dx*dx + dy*dy) * fps
-            prev_center[oid] = (cx, cy)
-
-            x1i, y1i = int(max(0, x1)), int(max(0, y1))
-            x2i, y2i = int(min(W, x2)), int(min(H, y2))
-            roi = frame[y1i:y2i, x1i:x2i] if frame is not None else np.array([])
-            hue,sat,val = hsv_stats(roi)
-            gray_roi = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY) if roi.size else np.array([])
-            edge = edge_density(gray_roi)
-
-            wr.writerow([round(t,3), stream_id, oid, cls,
-                         round(az,2), round(el,2), round(dist,3),
-                         round(spd,3), round(conf,3), round(gval,3),
-                         round(hue,1), round(sat,3), round(val,3), round(edge,3)])
-    out.close()
-
-if __name__ == "__main__":
-    p = argparse.ArgumentParser()
-    p.add_argument("video", help="path or RTSP/HTTP URL")
-    p.add_argument("--out", default="score.csv")
-    p.add_argument("--model", default="yolov8n.pt")  # start tiny; TRT later
-    p.add_argument("--imgsz", type=int, default=640)
-    p.add_argument("--conf", type=float, default=0.25)
-    p.add_argument("--stream_id", default="camA")
-    args = p.parse_args(); main(args)
-```
-
-### Run on a file
 ```bash
 cd analyzer
 python3 vid2score.py ../examples/input.mp4 --out ../examples/score_example.csv --stream_id camA
 ```
 
-### Run on a live stream (TouchDesigner tips)
-- In TD, for each **pre-mix source**, add **Stream Out TOP** (RTSP) *or* **NDI Out TOP**.
-- On the Jetson, pass the RTSP/HTTP URL as `video`. (NDI works too if you add a local NDI receiver that exposes frames/URL to OpenCV.)
+Want live video from TouchDesigner?  Add a **Stream Out TOP** (RTSP) or **NDI
+Out TOP** in TD and point the script at the URL:
+
 ```bash
 python3 vid2score.py "rtsp://<ip>:<port>/<name>" --out score_camA.csv --stream_id camA
 ```
 
-> **Best practice:** sniff each **input stream** for object-level timbres (clarity), and also sniff the **post-mix** once to extract macro “mood” controls.
+Best practice is to analyze each pre‑mix stream for object‑level timbres, then
+analyze the post‑mix once to pull out macro "mood" controls.
 
 ---
 
-## Renderer: multi-timbral, 20-voice budget (SuperCollider)
+## Running the renderer
 
-### Files you can run
-- `renderer/render.scd` — stereo renderer (Pan2), **20-voice** budget.
-- `renderer/render_ring8.scd` — 8‑channel ring renderer without external VBAP plugins (works on plain SC+plugins).
-- `renderer/mapping*.scd` — three presets in addition to the base `mapping.scd`:
-  - **Steel Mill** (fm metal + modal hits)
-  - **Neon Glass** (band‑noise + sheen)
-  - **Rust Choir** (slow drones + foldback grit)
+Open SuperCollider, start JACK, and load one of:
 
-Open SuperCollider, start JACK, run one of the renderers, then call `~playScore` with your CSV path.
+- `renderer/render.scd` — stereo, Pan2 based.
+- `renderer/render_ring8.scd` — 8‑channel ring without needing VBAP.
+
+Each mapping file in `renderer/` tweaks the personality of the voices.  Swap in
+`mapping_steel_mill.scd`, `mapping_neon_glass.scd`, or `mapping_rust_choir.scd`
+for different vibes.  They all respect the same 20‑voice budget.
+
+Once a renderer is running, call `~playScore` with the path to your CSV:
+
+```supercollider
+~playScore.("/full/path/to/examples/score_example.csv");
+```
+
+The renderer keeps a voice alive a few seconds after the last update so tails
+breathe instead of choking.
 
 ---
 
 ## Voice policy (musical & safe)
 
-- **Global cap:** `~MAX_VOICES = 20` (default).
-- **Per-stream soft cap:** `~PER_STREAM = 4`.
-- **Priority:** births > largest area > fastest.
-- **Hysteresis:** renderer keeps a voice alive a few seconds after last update so tails breathe.
+- **Global cap:** `~MAX_VOICES = 20`.
+- **Per stream soft cap:** `~PER_STREAM = 4`.
+- **Priority:** new voices beat loud voices which beat fast voices.  Something
+  has to win.
+- **Hysteresis:** letting notes hang for a moment keeps things human.
 
 ---
 
-## TouchDesigner bridging (quick)
+## TouchDesigner quick tips
 
-- **Pre-mix:** On each TD source, add **Stream Out TOP** (RTSP). Give unique names (camA, camB…).  
-- On Jetson, run one analyzer per stream (or round-robin a single process) and set `--stream_id` accordingly.  
-- **Post-mix:** Add another Stream Out TOP for the **final mix** and analyze to extract *macro* controls (you can add a second pass later that writes `macro.csv`).
-
----
-
-## Practical notes
-
-- Start with `yolov8n.pt`. If you need more FPS: export to **TensorRT** or step up to an Orin.
-- Keep detection `imgsz` at `640` or `512` for Nano comfort.
-- If footage has heavy stripes/flicker, the `glitch` metric will climb—map it to **bit depth**, **clock skew**, or **ratchet rate** for that beloved broken-machine energy.
+- On each TD source, add **Stream Out TOP** (RTSP) and give it a unique name
+  (`camA`, `camB`, ...).
+- Run one analyzer per stream on the Jetson and set `--stream_id` to match.
+- To sniff the final mix, add another Stream Out TOP and analyze it into a
+  second score (e.g. `macro.csv`).
 
 ---
 
 ## Roadmap
-- [ ] Optional **DeepStream** backend.
-- [ ] VBAP/FOA decoders for 8-out and binaural prints.
-- [ ] One-shot event bus on object birth/death.
-- [ ] JSON mapping (loadable at runtime) instead of `mapping.scd`.
-- [ ] Simple OSC live mode (Jetson → Renderer in real time).
+
+- [ ] Optional DeepStream backend.
+- [ ] VBAP/FOA decoders for 8‑out and binaural prints.
+- [ ] One‑shot event bus on object birth/death.
+- [ ] JSON mapping loaded at runtime instead of hard‑coding `mapping.scd`.
+- [ ] Simple OSC live mode (Jetson → renderer in real time).
 
 ---
 
 ## License
-MIT
+
+MIT, because art should travel.
 
 ---
 
-### Quickstart (TL;DR)
+### TL;DR quickstart
 
 ```bash
 # 1) Analyze a file
 cd analyzer
 python3 vid2score.py ../examples/input.mp4 --out ../examples/score_example.csv --stream_id camA
 
-# 2) Render it (SuperCollider)
+# 2) Render it (in SuperCollider)
 # open renderer/render.scd OR renderer/render_ring8.scd and run; adjust path in ~playScore
 ```
+

--- a/analyzer/vid2score.py
+++ b/analyzer/vid2score.py
@@ -1,84 +1,167 @@
 #!/usr/bin/env python3
-# File: analyzer/vid2score.py
-import argparse, csv, math, cv2, numpy as np
+"""Video/stream → CSV score writer.
+
+This script is meant to be small and readable.  It looks at every frame of a
+video (file or RTSP/HTTP URL), runs YOLO object detection, and writes a line of
+`score.csv` for each object it tracks.
+
+Each CSV row carries timestamp, object id/class, position in polar coords,
+speed, confidence, and a handful of goofy "character" features like color and
+edge density.  The SuperCollider renderer turns those numbers into synth
+parameters.
+"""
+
+import argparse
+import csv
+import math
+
+import cv2
+import numpy as np
 from ultralytics import YOLO
 
-def glitch_meter(gray):
-    sobelx = cv2.Sobel(gray, cv2.CV_32F, 1, 0, ksize=3)
-    return float(np.clip(np.mean(np.abs(sobelx))/64.0, 0.0, 1.0))
 
-def to_polar(cx, cy, area, W, H):
-    az  = (cx/W)*360.0 - 180.0
-    el  = (1 - cy/H)*60.0 - 30.0
-    dist = max(0.05, 1.0 - area/(W*H))
+def glitch_meter(gray: np.ndarray) -> float:
+    """Estimate how broken a frame looks.
+
+    Uses a Sobel edge detector and averages the absolute value.  Lots of harsh
+    horizontal lines push the value toward 1.0.
+    """
+
+    sobelx = cv2.Sobel(gray, cv2.CV_32F, 1, 0, ksize=3)
+    return float(np.clip(np.mean(np.abs(sobelx)) / 64.0, 0.0, 1.0))
+
+
+def to_polar(cx: float, cy: float, area: float, W: int, H: int) -> tuple[float, float, float]:
+    """Convert pixel coordinates and area into rough polar coordinates.
+
+    Returns azimuth (degrees left/right of center), elevation (degrees up/down)
+    and a fake distance metric based on bounding‑box area.
+    """
+
+    az = (cx / W) * 360.0 - 180.0
+    el = (1 - cy / H) * 60.0 - 30.0
+    dist = max(0.05, 1.0 - area / (W * H))
     return az, el, dist
 
-def hsv_stats(bgr_roi):
-    if bgr_roi.size == 0: return 0.0,0.0,0.0
+
+def hsv_stats(bgr_roi: np.ndarray) -> tuple[float, float, float]:
+    """Return average hue/saturation/value for a region of interest."""
+
+    if bgr_roi.size == 0:
+        return 0.0, 0.0, 0.0
     hsv = cv2.cvtColor(bgr_roi, cv2.COLOR_BGR2HSV)
-    h = float(np.mean(hsv[:,:,0]) * 2.0)       # 0..360°
-    s = float(np.mean(hsv[:,:,1]) / 255.0)     # 0..1
-    v = float(np.mean(hsv[:,:,2]) / 255.0)     # 0..1
-    return h,s,v
+    h = float(np.mean(hsv[:, :, 0]) * 2.0)  # 0..360°
+    s = float(np.mean(hsv[:, :, 1]) / 255.0)  # 0..1
+    v = float(np.mean(hsv[:, :, 2]) / 255.0)  # 0..1
+    return h, s, v
 
-def edge_density(gray_roi):
-    if gray_roi.size == 0: return 0.0
-    return float(np.clip(cv2.Laplacian(gray_roi, cv2.CV_32F).var()/1000.0, 0.0, 1.0))
 
-def main(args):
-    cap  = cv2.VideoCapture(args.video)
+def edge_density(gray_roi: np.ndarray) -> float:
+    """How edgy is the ROI? (0..1)"""
+
+    if gray_roi.size == 0:
+        return 0.0
+    return float(np.clip(cv2.Laplacian(gray_roi, cv2.CV_32F).var() / 1000.0, 0.0, 1.0))
+
+
+def main(args: argparse.Namespace) -> None:
+    """Open the video, run tracking, and write the score."""
+
+    cap = cv2.VideoCapture(args.video)
     assert cap.isOpened(), f"Cannot open {args.video}"
-    fps  = cap.get(cv2.CAP_PROP_FPS) or 30.0
-    W    = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
-    H    = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+    W = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    H = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
     model = YOLO(args.model)
 
-    prev_center = {}
+    prev_center: dict[int, tuple[float, float]] = {}
     t = 0.0
     out = open(args.out, "w", newline="")
     wr = csv.writer(out)
-    wr.writerow(["t","stream","oid","cls","az","el","dist","spd","conf","glitch","hue","sat","val","edge"])
+    wr.writerow([
+        "t",
+        "stream",
+        "oid",
+        "cls",
+        "az",
+        "el",
+        "dist",
+        "spd",
+        "conf",
+        "glitch",
+        "hue",
+        "sat",
+        "val",
+        "edge",
+    ])
     stream_id = args.stream_id
 
-    for r in model.track(source=args.video, stream=True, imgsz=args.imgsz, conf=args.conf, verbose=False):
-        t += 1.0/fps
+    # Iterate over detection results from YOLO's built-in tracker.
+    for r in model.track(
+        source=args.video,
+        stream=True,
+        imgsz=args.imgsz,
+        conf=args.conf,
+        verbose=False,
+    ):
+        t += 1.0 / fps
         frame = getattr(r, "orig_img", None)
         gval = 0.0
         if frame is not None:
+            # rough glitch indicator based on horizontal edges
             gval = glitch_meter(cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY))
         boxes = r.boxes
-        if boxes is None: continue
+        if boxes is None:
+            continue
 
         for b in boxes:
-            if b.id is None: continue
-            oid  = int(b.id.item())
-            cls  = int(b.cls.item())
+            if b.id is None:
+                continue
+            oid = int(b.id.item())
+            cls = int(b.cls.item())
             conf = float(b.conf.item())
 
-            x1,y1,x2,y2 = [float(v) for v in b.xyxy[0].tolist()]
-            cx, cy = (x1+x2)/2, (y1+y2)/2
-            area   = max(1.0, (x2-x1)*(y2-y1))
+            x1, y1, x2, y2 = [float(v) for v in b.xyxy[0].tolist()]
+            cx, cy = (x1 + x2) / 2, (y1 + y2) / 2
+            area = max(1.0, (x2 - x1) * (y2 - y1))
             az, el, dist = to_polar(cx, cy, area, W, H)
 
+            # speed in normalized pixels per second
             spd = 0.0
             if oid in prev_center:
                 px, py = prev_center[oid]
-                dx, dy = (cx-px)/W, (cy-py)/H
-                spd = math.sqrt(dx*dx + dy*dy) * fps
+                dx, dy = (cx - px) / W, (cy - py) / H
+                spd = math.sqrt(dx * dx + dy * dy) * fps
             prev_center[oid] = (cx, cy)
 
+            # crop region of interest for color/edge features
             x1i, y1i = int(max(0, x1)), int(max(0, y1))
             x2i, y2i = int(min(W, x2)), int(min(H, y2))
             roi = frame[y1i:y2i, x1i:x2i] if frame is not None else np.array([])
-            hue,sat,val = hsv_stats(roi)
+            hue, sat, val = hsv_stats(roi)
             gray_roi = cv2.cvtColor(roi, cv2.COLOR_BGR2GRAY) if roi.size else np.array([])
             edge = edge_density(gray_roi)
 
-            wr.writerow([round(t,3), stream_id, oid, cls,
-                         round(az,2), round(el,2), round(dist,3),
-                         round(spd,3), round(conf,3), round(gval,3),
-                         round(hue,1), round(sat,3), round(val,3), round(edge,3)])
+            wr.writerow(
+                [
+                    round(t, 3),
+                    stream_id,
+                    oid,
+                    cls,
+                    round(az, 2),
+                    round(el, 2),
+                    round(dist, 3),
+                    round(spd, 3),
+                    round(conf, 3),
+                    round(gval, 3),
+                    round(hue, 1),
+                    round(sat, 3),
+                    round(val, 3),
+                    round(edge, 3),
+                ]
+            )
     out.close()
+
 
 if __name__ == "__main__":
     p = argparse.ArgumentParser()
@@ -88,4 +171,6 @@ if __name__ == "__main__":
     p.add_argument("--imgsz", type=int, default=640)
     p.add_argument("--conf", type=float, default=0.25)
     p.add_argument("--stream_id", default="camA")
-    args = p.parse_args(); main(args)
+    args = p.parse_args()
+    main(args)
+

--- a/renderer/mapping.scd
+++ b/renderer/mapping.scd
@@ -1,12 +1,15 @@
 (
-// class → family
+// Mapping file: decides which detection classes trigger which sonic "families"
+// and how features from the CSV map onto synth parameters.
+
+// class → family (only a few example classes for now)
 ~classToFamily = (
     0: \servo,     // person
     39: \hiss,     // bottle
     41: \punch     // cup
 );
 
-// family → synth engine + param ranges (low..high)
+// family → synth engine + parameter ranges (low..high)
 ~families = (
     servo: (engine: \fm,   ranges: (ratio: [1.0, 3.0], index: [0.2, 6.0], cutoff: [800, 8000])),
     hiss:  (engine: \noise, ranges: (center: [2000, 12000], q: [1.0, 12.0], rate: [2.0, 40.0])),
@@ -14,18 +17,18 @@
     arc:   (engine: \fold, ranges: (bias: [0, 1], fold: [0, 6], spray: [0,1]))
 );
 
-// routing: feature → param scaler (srcMin, srcMax → dstMin, dstMax)
+// routing: feature → parameter scaler (srcMin, srcMax → dstMin, dstMax)
 ~routing = (
-    az_to_pan:       [-180, 180,  -1, 1],
-    dist_to_cutoff:  [1, 0,  500, 8000],
+    az_to_pan:       [-180, 180,  -1, 1],          // left/right
+    dist_to_cutoff:  [1, 0,  500, 8000],           // near = bright
     spd_to_index:    [0, 1,  0.3, 6.0],
     edge_to_q:       [0, 1,  0.7, 12.0],
-    sat_to_drive:    [0, 1,  0.0, 18.0],   // dB into soft clip
+    sat_to_drive:    [0, 1,  0.0, 18.0],           // dB into soft clip
     val_to_reverb:   [0, 1,  0.1, 0.8],
     glitch_to_bits:  [0, 1,  16, 4]
 );
 
-// budgets
+// voice budgets
 ~MAX_VOICES = 20;      // global cap
 ~PER_STREAM = 4;       // soft cap per stream
 )

--- a/renderer/render.scd
+++ b/renderer/render.scd
@@ -1,19 +1,21 @@
-// File: renderer/render.scd
-s.options.numOutputBusChannels = 2;  // change to 8 or use render_ring8.scd for a ring
+// Renderer: turn score.csv into sound.
+// Run this in SuperCollider after booting the server.  Up to 20 voices will
+// spawn, one per tracked object.  For 8‑channel output use render_ring8.scd.
+s.options.numOutputBusChannels = 2;
 s.boot;
 
 (
-~scaler = { |v, a,b, c,d| (v.clip(a,b)-a)/(b-a) * (d-c) + c };
-~voices = IdentityDictionary.new;
-~perStreamCounts = ();
+~scaler = { |v, a,b, c,d| (v.clip(a,b)-a)/(b-a) * (d-c) + c }; // simple value mapper
+~voices = IdentityDictionary.new;  // active synths keyed by "stream:oid"
+~perStreamCounts = ();             // how many voices per stream this tick
 
-// ===== engines =====
+// ===== engines (the actual synths) =====
 SynthDef(\engine_fm, { |out=0, pan=0, ratio=1, index=1, cutoff=4000, drive=0, amp=0.15|
-    var carHz = Lag.kr(60, 0.2) * ratio;
-    var mod = SinOsc.ar(carHz * ratio, 0, carHz*index);
+    var carHz = Lag.kr(60, 0.2) * ratio;               // base pitch ~60 Hz
+    var mod = SinOsc.ar(carHz * ratio, 0, carHz*index); // FM modulator
     var sig = SinOsc.ar(carHz + mod);
-    sig = RLPF.ar(sig, cutoff.clip(100,18000), 0.3);
-    sig = (sig * (1 + drive.dbamp)).tanh;
+    sig = RLPF.ar(sig, cutoff.clip(100,18000), 0.3);    // simple low‑pass
+    sig = (sig * (1 + drive.dbamp)).tanh;               // soft clip
     Out.ar(out, Pan2.ar(sig, pan, amp));
 }).add;
 
@@ -26,17 +28,19 @@ SynthDef(\engine_noise, { |out=0, pan=0, center=4000, q=4, rate=8, drive=0, amp=
 }).add;
 
 SynthDef(\engine_modal, { |out=0, pan=0, baseHz=120, damp=0.4, hit=0.0, drive=0, amp=0.2|
+    // tiny three‑resonator drum
     var exc = Decay2.kr(TDuty.kr(Impulse.kr(hit*20 + 0.1), 0, 1), 0.001, 0.02);
     var sig = Klank.ar(Ref([[baseHz, baseHz*1.25, baseHz*1.5], [1,0.8,0.7], [damp,damp*0.7,damp*0.5]]), WhiteNoise.ar*exc);
     sig = (sig * (1 + drive.dbamp)).tanh;
     Out.ar(out, Pan2.ar(sig, pan, amp));
 }).add;
 
-// ===== default mapping =====
+// ===== load mapping file (class→timbre) =====
 this.executeFile((thisProcess.nowExecutingPath.dirname +/+ "mapping.scd"));
 
-// ===== helpers =====
+// ===== helper functions =====
 ~spawn = { |key, family, pan=0, amp=0.18|
+    // instantiate a synth for a new object
     var engine = ~families[family].engine;
     var name = switch(engine, \fm, { \engine_fm }, \noise, { \engine_noise }, \modal, { \engine_modal }, \fold, { \engine_noise });
     var syn = Synth(name, [\pan, pan, \amp, amp]);
@@ -44,10 +48,11 @@ this.executeFile((thisProcess.nowExecutingPath.dirname +/+ "mapping.scd"));
 };
 
 ~setParams = { |syn, fam, feats|
+    // map features from the CSV into synth parameters
     var r = ~families[fam].ranges;
     var p = ();
-    p[\pan]    = ~scaler.(feats[\az], *~routing[\az_to_pan]);
-    p[\drive]  = ~scaler.(feats[\sat], *~routing[\sat_to_drive]);
+    p[\pan]   = ~scaler.(feats[\az], *~routing[\az_to_pan]);
+    p[\drive] = ~scaler.(feats[\sat], *~routing[\sat_to_drive]);
     switch(~families[fam].engine,
         \fm, {
             p[\ratio]  = ~scaler.(feats[\edge], 0,1, r[\ratio][0], r[\ratio][1]);
@@ -69,11 +74,13 @@ this.executeFile((thisProcess.nowExecutingPath.dirname +/+ "mapping.scd"));
 };
 
 ~eligible = { |stream|
+    // enforce global/per‑stream voice limits
     var c = (~perStreamCounts[stream] ? 0);
     ( ~voices.size < ~MAX_VOICES ) && ( c < ~PER_STREAM );
 };
 
 ~tickCounts = {
+    // recompute per‑stream counts each control tick
     ~perStreamCounts = ();
     ~voices.keysValuesDo { |key, rec|
         var stream = key.split($:).first;
@@ -82,6 +89,7 @@ this.executeFile((thisProcess.nowExecutingPath.dirname +/+ "mapping.scd"));
 };
 
 ~playScore = { |scorePath|
+    // read the CSV in a routine so timing survives
     var f = File(scorePath, "r"); var header = f.getLine;
     var t0 = thisThread.seconds;
     Routine({
@@ -114,7 +122,7 @@ this.executeFile((thisProcess.nowExecutingPath.dirname +/+ "mapping.scd"));
         });
         f.close;
 
-        3.wait;
+        3.wait;                                // let tails ring
         ~voices.do { |rec| rec[\s].free };
         ~voices.clear;
     }).play(AppClock);

--- a/renderer/render_ring8.scd
+++ b/renderer/render_ring8.scd
@@ -1,4 +1,6 @@
-// File: renderer/render_ring8.scd
+// Renderer for 8 speakers in a ring.
+// Same idea as render.scd but instead of stereo panning we drop energy into a
+// circular array of eight outputs.
 s.options.numOutputBusChannels = 8;
 s.boot;
 


### PR DESCRIPTION
## Summary
- Rewrite README as a friendly studio-log style guide
- Annotate vid2score analyzer with docstrings and step-by-step comments
- Comment SuperCollider renderers and mapping for clearer voice mapping

## Testing
- `python3 -m py_compile analyzer/vid2score.py`
- `sclang -h` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e05db4cc8325b42f16a100d06caf