### PR TITLE
Add color/brightness-based shape score to analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Picture a security camera feeding a garage band.
   when life gives you beautiful Jetsons, you run things like: SuperCollider, 
   JACK, and a Jetson that you probably already cooked noodles on.
 - **Every object gets a personality.** The analyzer measures position, speed,
-  color, even a janky "glitch" metric.  The renderer maps those numbers to
-  timbre.
+  color, **shape**, and even a janky "glitch" metric.  The renderer maps those
+  numbers to timbre.
 - **Live or offline.** Feed it prerecorded footage, or sling live frames from
   TouchDesigner over RTSP/NDI.
 
@@ -96,7 +96,7 @@ sudo nvpmodel -m 0 && sudo jetson_clocks
 
 ## Running the analyzer
 
-The script writes a newline‑timed score with spatial and color features.  The
+The script writes a newline‑timed score with spatial, color, and shape features.  The
 score is just text; open it in a spreadsheet if that makes you smile.
 
 ```bash

--- a/examples/score_example.csv
+++ b/examples/score_example.csv
@@ -1,1 +1,1 @@
-t,stream,oid,cls,az,el,dist,spd,conf,glitch,hue,sat,val,edge
+t,stream,oid,cls,az,el,dist,spd,conf,glitch,hue,sat,val,edge,shape


### PR DESCRIPTION
## Summary
- conjure a `shape_magic` helper that distills contour compactness, brightness, and hue variance into a 0-1 shape score
- thread that shape score through the analyzer and score output, birthing a new `shape` column
- document the new mojo and update the example CSV header

## Testing
- `python -m py_compile analyzer/vid2score.py`
- `python analyzer/vid2score.py --help` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install opencv-python-headless` *(fails: Could not find a version that satisfies the requirement opencv-python-headless)*

------
https://chatgpt.com/codex/tasks/task_e_68b9e398d5108325a5d393a32e3aeeef