### PR TITLE
Add Processing sketch for webcam-driven sine waves

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ small and loud on purpose so you can read it like liner notes.
 
 ## In plain English
 
-There are only two moving parts:
+There are two main moving parts (plus a lo-fi Processing sketch if you want to stay in Java land):
 
 1. **Analyzer** (`analyzer/vid2score.py`)
    - Python script that runs on a Jetson Nano (or any CUDA Jetson).
@@ -19,6 +19,8 @@ There are only two moving parts:
 2. **Renderer** (`renderer/render.scd` or `renderer/render_ring8.scd`)
    - SuperCollider patch that reads the score and gives every object a voice.
    - Default budget is **20 voices**, so things stay musical instead of mush.
+3. **Processing sketch** (`processing/VidObjectifierProcessing.pde`)
+   - Webcam-in, sine-wave-out demo that skips Python and SuperCollider.
 
 Picture a security camera feeding a garage band.
 
@@ -64,6 +66,9 @@ Picture a security camera feeding a garage band.
 ├── examples/
 │   ├── input.mp4              # drop your video here
 │   └── score_example.csv      # tiny header-only example
+├── processing/
+│   ├── VidObjectifierProcessing.pde # webcam → sine wave demo
+│   └── README.md                    # how to run the gremlin
 └── README.md                  # you are here
 ```
 
@@ -135,6 +140,12 @@ Once a renderer is running, call `~playScore` with the path to your CSV:
 
 The renderer keeps a voice alive a few seconds after the last update so tails
 breathe instead of choking.
+
+---
+
+## Processing quickie
+
+If you're allergic to command lines or just want a one-file noise gremlin, peek at `processing/VidObjectifierProcessing.pde`. Open it in the Processing IDE, install the **Minim** library, and run. The brightest spot in the camera maps to a sine wave's pitch and volume. It's cheap and dirty and that's the point.
 
 ---
 

--- a/processing/README.md
+++ b/processing/README.md
@@ -1,0 +1,33 @@
+# Processing Noise Gremlin
+
+Welcome to the **lo-fi, all-in-one** version of VidObjectifier. This sketch watches your webcam and spits out a single sine wave whose pitch and volume chase the brightest blob in view. It's the punk little cousin of the Python analyzer and SuperCollider renderer.
+
+## Why this exists
+
+Some folks just want to crack open Processing, hit run, and get weird. No Python, no SuperCollider, just straight Java vibes. This sketch keeps it simple so you can poke at the ideas quickly.
+
+## How to run it
+
+1. Install [Processing](https://processing.org/).
+2. In Processing, go to **Sketch → Import Library → Add Library** and install **Minim**.
+3. Drop the `VidObjectifierProcessing.pde` file into its own folder named `VidObjectifierProcessing` (Processing loves matching names).
+4. Open the sketch and smash the **Run** button.
+5. Point a flashlight, your phone screen, or a shiny object at the camera and hear the pitch go wild.
+
+## What it's doing
+
+- Grabs frames from your default webcam.
+- Searches each frame for the brightest pixel.
+- Draws a red dot on that pixel so you can see what's driving the sound.
+- Maps horizontal position → frequency and brightness → amplitude.
+- A lone sine oscillator drones along based on those values.
+
+## Where to hack
+
+- Swap the sine wave for something gnarlier in the `Oscil` setup.
+- Use Processing's `Movie` class instead of `Capture` to analyze prerecorded video.
+- Add more oscillators and let each bright blob own a voice.
+
+## Disclaimer
+
+This is not high art. It's a teaching tool and a playground. If you crash it, break it, or make it scream, you're doing it right.

--- a/processing/VidObjectifierProcessing.pde
+++ b/processing/VidObjectifierProcessing.pde
@@ -1,0 +1,81 @@
+// VidObjectifierProcessing.pde
+// A punk-rock Processing sketch that watches your webcam and screams in sine waves.
+// Think of it as the scrappy cousin to the Python+SuperCollider chain.
+//
+// Dependencies:
+//   - Processing (https://processing.org/)
+//   - Video library (comes with Processing)
+//   - Minim audio library (install via Sketch → Import Library → Add Library)
+//
+// This file is littered with comments because students deserve to know what's going on.
+// Run it from the Processing IDE or via processing-java.
+
+import processing.video.*;      // Grab frames from webcam or video file
+import ddf.minim.*;             // Friendly audio toolkit
+import ddf.minim.ugens.*;       // Oscillator objects live here
+
+Capture cam;        // Video capture object
+Minim minim;        // Minim engine
+AudioOutput out;    // Where sound is pushed
+Oscil osc;          // A single sine oscillator — our lone noisy voice
+
+// setup() runs once when the sketch starts.
+void setup() {
+  size(640, 480);                       // Set window size
+
+  // Fire up the webcam. Processing will nag you if none is found.
+  cam = new Capture(this, 640, 480);    // width, height
+  cam.start();                          // Start grabbing frames
+
+  // Kick the audio engine into gear and patch a silent oscillator to it.
+  minim = new Minim(this);
+  out = minim.getLineOut();             // Stereo out
+  osc = new Oscil(440, 0.0, Waves.SINE); // 440Hz but silent at start
+  osc.patch(out);                       // Connect osc → speakers
+}
+
+// draw() loops forever. Each pass is a frame.
+void draw() {
+  background(0);                        // Black canvas each frame
+
+  // Pull in a new frame if available.
+  if (cam.available()) {
+    cam.read();
+  }
+  cam.loadPixels();                     // Lets us read pixel array
+  image(cam, 0, 0);                     // Paint the camera frame to the window
+
+  // Find the brightest pixel in the frame.
+  int brightestIndex = 0;
+  float brightestValue = 0;
+  for (int i = 0; i < cam.pixels.length; i++) {
+    float b = brightness(cam.pixels[i]);
+    if (b > brightestValue) {
+      brightestValue = b;
+      brightestIndex = i;
+    }
+  }
+
+  // Convert 1D pixel index back to 2D position.
+  int x = brightestIndex % cam.width;
+  int y = brightestIndex / cam.width;
+
+  // Draw a red circle where the brightest pixel lives.
+  noStroke();
+  fill(255, 0, 0);
+  ellipse(x, y, 20, 20);
+
+  // Map the x position to pitch and brightness to volume.
+  float freq = map(x, 0, cam.width, 100, 1000);      // 100Hz → 1kHz
+  float amp = map(brightestValue, 0, 255, 0, 0.5);   // Stay under clipping
+  osc.setFrequency(freq);
+  osc.setAmplitude(amp);
+}
+
+// When the window closes, unpatch and clean up.
+void stop() {
+  osc.unpatch(out);
+  out.close();
+  minim.stop();
+  super.stop();
+}


### PR DESCRIPTION
## Summary
- add Processing sketch that maps webcam brightness to sine-wave pitch and volume
- document Processing sketch and wire it into main README

## Testing
- `python3 -m py_compile analyzer/vid2score.py`
- `processing-java --sketch=processing --run` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1043831483258d3fad30c1060a10